### PR TITLE
Add article for failing transaction warning when sending multiple transactions

### DIFF
--- a/user-guide/troubleshooting/pretransaction-shows-failure-warning.html
+++ b/user-guide/troubleshooting/pretransaction-shows-failure-warning.html
@@ -1,0 +1,9 @@
+<p>
+  When the client asks you to sign and send multiple transactions to the Ethereum blockchain, your Ethereum provider (e.g. MetaMask) may warn you that the subsequent transactions will fail.
+</p>
+<p>
+  This is due to the Ethereum blockchain not yet having been updated from your initial transactions, which makes it impossible for the Ethereum provider to determine whether the subsequent transactions will succeed or fail.
+</p>
+<p>
+  You should be able to safely ignore these warnings, as the Aragon client will have already pre-computed the state required to ensure your transactions will succeed.
+</p>


### PR DESCRIPTION
Fixes #14 (see https://github.com/aragon/aragon/pull/1267).

~~I was looking for a screenshot of MetaMask showing this warning, but wasn't able to produce it anymore.~~

Found an example where this happens:

<img width="360" alt="Screen Shot 2020-01-24 at 3 06 38 PM" src="https://user-images.githubusercontent.com/4166642/73075022-3bb8e180-3ebb-11ea-9419-fb3de8f4c939.png">